### PR TITLE
Don't increment b:changedtick, offer invalidate instead.

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -37,8 +37,13 @@ let g:loaded_repeat = 1
 
 let g:repeat_tick = -1
 
+" Special function to avoid spurious repeats in a related, naturally repeating
+" mapping when your repeatable mapping doesn't increase b:changedtick.
+function! repeat#invalidate()
+    let g:repeat_tick = -1
+endfunction
+
 function! repeat#set(sequence,...)
-    call setline(line('.'), getline('.'))
     let g:repeat_sequence = a:sequence
     let g:repeat_count = a:0 ? a:1 : v:count
     let g:repeat_tick = b:changedtick


### PR DESCRIPTION
repeat#set() so far automatically incremented b:changedtick. Problems
with this:
1. The way that was done clobbered the expression register "=.
2. It causes the "readonly" warning and "Cannot make changes" error in
   readonly/nomodifiable buffers, so mappings that don't modify anything
   cannot be repeated there.
3. It's actually not needed most of the time, because many user mappings
   and all repeatable Vim built-in normal mode commands I know (with the
   exception of yank with cpo+=y) actually do modify the buffer
   themselves.

For the exceptional case where the user has a set of related mappings,
one that repeats naturally (e.g. a custom operator, via g@), and one
that invokes repeat#set(), and both do not modify the buffer, a new
function repeat#invalidate() is offered. This should be called by the
former mapping, and all is well.
