### PR TITLE
Fix adding trailing spaces when 'virtualedit' isn't empty

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -38,7 +38,7 @@ let g:loaded_repeat = 1
 let g:repeat_tick = -1
 
 function! repeat#set(sequence,...)
-    silent exe "norm! \"=''\<CR>p"
+    call setline(line('.'), getline('.'))
     let g:repeat_sequence = a:sequence
     let g:repeat_count = a:0 ? a:1 : v:count
     let g:repeat_tick = b:changedtick


### PR DESCRIPTION
The problem appears when cursor is positioned after line end, thus running p command (even with empty "-register) causes Vim to add spaces from line end until cursor.

I found this issue while using vim-commentary. It's quite annoying when trailing spaces appear almost each time I comment or uncomment one line.

I'm not a VimL expert at all, so I think you could know a better fix for the issue.
