### PR TITLE
Go back to using feedkeys(), but restore typeahead

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -84,9 +84,10 @@ function! repeat#run(count)
         let c = g:repeat_count
         let s = g:repeat_sequence
         let cnt = c == -1 ? "" : (a:count ? a:count : (c ? c : ''))
-        exe 'norm ' . r . cnt . s
+        call feedkeys(r . cnt, 'n')
+        call feedkeys(s)
     else
-        exe 'norm! '.(a:count ? a:count : '') . '.'
+        call feedkeys((a:count ? a:count : '') . '.', 'n')
     endif
 endfunction
 


### PR DESCRIPTION
Since there seems to be a bug with "norm" in Vim prior to 7.3.100, better go back to using feedkeys.

To make that work with a custom mapping, the rest of the typeahead buffer is consumed and then fed back.

Update: Since the typeahead restoration is fairly convoluted, just go back to using `feedkeys()`.
