### PR TITLE
Allow customizing all mappings

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -91,7 +91,7 @@ function! repeat#run(count)
     endif
 endfunction
 
-function! s:wrap(command,count)
+function! repeat#wrap(command,count)
     let preserve = (g:repeat_tick == b:changedtick)
     exe 'norm! '.(a:count ? a:count : '').a:command . (&foldopen =~# 'undo' ? 'zv' : '')
     if preserve
@@ -100,11 +100,11 @@ function! s:wrap(command,count)
 endfunction
 
 nnoremap <silent> .     :<C-U>call repeat#run(v:count)<CR>
-nnoremap <silent> u     :<C-U>call <SID>wrap('u',v:count)<CR>
+nnoremap <silent> u     :<C-U>call repeat#wrap('u',v:count)<CR>
 if maparg('U','n') ==# ''
-    nnoremap <silent> U     :<C-U>call <SID>wrap('U',v:count)<CR>
+    nnoremap <silent> U     :<C-U>call repeat#wrap('U',v:count)<CR>
 endif
-nnoremap <silent> <C-R> :<C-U>call <SID>wrap("\<Lt>C-R>",v:count)<CR>
+nnoremap <silent> <C-R> :<C-U>call repeat#wrap("\<Lt>C-R>",v:count)<CR>
 
 augroup repeatPlugin
     autocmd!


### PR DESCRIPTION
f1d0fbbdf4d77b73ba47146bada375223b3d733a allowed customizing the . mapping by making the implementation function publicly accessible. Let's do the same to `s:wrap()`, so that the other mappings (`u`, `U`, `<C-R>`) can be extended, too.

(Personally, I'd like to have undo / redo stop and beep at the last saved position, to avoid that I accidentally undo beyond the saved state even though I didn't intend to.)
