### PR TITLE
Documentation fix for repeat#setreg()

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -40,7 +40,7 @@
 " in your mapping will look like this:
 "
 "   nnoremap <silent> <Plug>MyMap
-"   \   :<C-U>silent! call repeat#setreg("\<lt>Plug>MyMap", v:register)<Bar>
+"   \   :<C-U>execute 'silent! call repeat#setreg("\<lt>Plug>MyMap", v:register)'<Bar>
 "   \   call <SID>MyFunction(v:register, ...)<Bar>
 "   \   silent! call repeat#set("\<lt>Plug>MyMap")<CR>
 


### PR DESCRIPTION
Need to `:execute` the `:silent!` call to avoid that the remainder of the
command line is aborted together with the call when repeat.vim is not
installed. Otherwise, `<SID>MyFunction()` won't be invoked, and the
mapping does nothing.

David Kotchan reported this problem for one of my plugins, I fixed the problem there; now, it would be nice if the documentation for this (rarely used) feature is corrected, too.
