### PR TITLE
Prevent "Press ENTER or type command to continue"

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -88,10 +88,10 @@ function! repeat#run(count)
         let c = g:repeat_count
         let s = g:repeat_sequence
         let cnt = c == -1 ? "" : (a:count ? a:count : (c ? c : ''))
-        call feedkeys(r . cnt, 'n')
-        call feedkeys(s)
+        silent! call feedkeys(r . cnt, 'n')
+        silent! call feedkeys(s)
     else
-        call feedkeys((a:count ? a:count : '') . '.', 'n')
+        silent! call feedkeys((a:count ? a:count : '') . '.', 'n')
     endif
 endfunction
 


### PR DESCRIPTION
Do not show "Press ENTER or type command to continue" message after type ".". Prepend "silent!"
