### PR TITLE
Fix hiding of Vim's internal undo/redo messages

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -97,7 +97,8 @@ endfunction
 
 function! repeat#wrap(command,count)
     let preserve = (g:repeat_tick == b:changedtick)
-    exe 'norm! '.(a:count ? a:count : '').a:command . (&foldopen =~# 'undo' ? 'zv' : '')
+    call feedkeys((a:count ? a:count : '').a:command, 'n')
+    exe (&foldopen =~# 'undo' ? 'norm! zv' : '')
     if preserve
         let g:repeat_tick = b:changedtick
     endif


### PR DESCRIPTION
Patch from @wilywampa.

Fixes: https://github.com/tpope/vim-repeat/issues/27
