### PR TITLE
Fix invalidate() being overridden by autocmd

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -55,6 +55,7 @@ let g:repeat_reg = ['', '']
 " Special function to avoid spurious repeats in a related, naturally repeating
 " mapping when your repeatable mapping doesn't increase b:changedtick.
 function! repeat#invalidate()
+    autocmd! repeat_custom_motion
     let g:repeat_tick = -1
 endfunction
 


### PR DESCRIPTION
If `repeat#invalidate()` is called immediately after `repeat#set()`, `g:repeat_tick` is set by the autocmd as soon as the cursor moves which defeats the purpose of `invalidate()`.