### PR TITLE
Pass flag 'i' to feedkeys() call

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -89,17 +89,17 @@ function! repeat#run(count)
         let c = g:repeat_count
         let s = g:repeat_sequence
         let cnt = c == -1 ? "" : (a:count ? a:count : (c ? c : ''))
-        if (v:version > 703 || (v:version == 703 && has('patch100')))
+        if ((v:version == 703 && has('patch100')) || (v:version == 704 && !has('patch601')))
             exe 'norm ' . r . cnt . s
         else
-            call feedkeys(r . cnt, 'n')
-            call feedkeys(s)
+            call feedkeys(r . cnt, 'ni')
+            call feedkeys(s, 'i')
         endif
     else
-        if (v:version > 703 || (v:version == 703 && has('patch100')))
+        if ((v:version == 703 && has('patch100')) || (v:version == 704 && !has('patch601')))
             exe 'norm! '.(a:count ? a:count : '') . '.'
         else
-            call feedkeys((a:count ? a:count : '') . '.', 'n')
+            call feedkeys((a:count ? a:count : '') . '.', 'ni')
         endif
     endif
 endfunction


### PR DESCRIPTION
Similar to #36, fixes #23 by passing the new flag `'i'` to `feedkeys()` that is available since [Patch 7.4.601](https://groups.google.com/forum/?fromgroups#!topic/vim_dev/qxf0yYZu52Y).

I also tested on Vim 7.3 to ensure compatibility. The unknown flag `'i'` is just silently ignored. So we don't need any version checks here.