### PR TITLE
more convenient remapping by using <plug> mappings

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -112,12 +112,17 @@ function! repeat#wrap(command,count)
     endif
 endfunction
 
-nnoremap <silent> .     :<C-U>call repeat#run(v:count)<CR>
-nnoremap <silent> u     :<C-U>call repeat#wrap('u',v:count)<CR>
-if maparg('U','n') ==# ''
-    nnoremap <silent> U     :<C-U>call repeat#wrap('U',v:count)<CR>
+nnoremap <silent> <Plug>(RepeatDot)      :<C-U>call repeat#run(v:count)<CR>
+nnoremap <silent> <Plug>(RepeatUndo)     :<C-U>call repeat#wrap('u',v:count)<CR>
+nnoremap <silent> <Plug>(RepeatUndoLine) :<C-U>call repeat#wrap('U',v:count)<CR>
+nnoremap <silent> <Plug>(RepeatRedo)     :<C-U>call repeat#wrap("\<Lt>C-R>",v:count)<CR>
+
+if !hasmapto('<Plug>(RepeatDot)', 'n')  | nmap . <Plug>(RepeatDot)      | endif
+if !hasmapto('<Plug>(RepeatUndo)', 'n') | nmap u <Plug>(RepeatUndo)     | endif
+if maparg('U','n') ==# '' && !hasmapto('<Plug>(RepeatUndoLine)', 'n')
+    nmap U <Plug>(RepeatUndoLine)
 endif
-nnoremap <silent> <C-R> :<C-U>call repeat#wrap("\<Lt>C-R>",v:count)<CR>
+if !hasmapto('<Plug>(RepeatRedo)', 'n') | nmap <C-R> <Plug>(RepeatRedo) | endif
 
 augroup repeatPlugin
     autocmd!


### PR DESCRIPTION
Now mappings can be remapped in `.vimrc` by
`nnoremap <key> <Plug>(RepeatUndoLine)`
and disablabled in `.vimrc` by
`nnoremap <SID>(DisableRepeatUndoLine) <Plug>(RepeatUndoLine)`