### PR TITLE
remove trailing spaces in remaps

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -117,12 +117,12 @@ nnoremap <silent> <Plug>(RepeatUndo)     :<C-U>call repeat#wrap('u',v:count)<CR>
 nnoremap <silent> <Plug>(RepeatUndoLine) :<C-U>call repeat#wrap('U',v:count)<CR>
 nnoremap <silent> <Plug>(RepeatRedo)     :<C-U>call repeat#wrap("\<Lt>C-R>",v:count)<CR>
 
-if !hasmapto('<Plug>(RepeatDot)', 'n')  | nmap . <Plug>(RepeatDot)      | endif
-if !hasmapto('<Plug>(RepeatUndo)', 'n') | nmap u <Plug>(RepeatUndo)     | endif
+if !hasmapto('<Plug>(RepeatDot)', 'n')  | nmap . <Plug>(RepeatDot)| endif
+if !hasmapto('<Plug>(RepeatUndo)', 'n') | nmap u <Plug>(RepeatUndo)| endif
 if maparg('U','n') ==# '' && !hasmapto('<Plug>(RepeatUndoLine)', 'n')
     nmap U <Plug>(RepeatUndoLine)
 endif
-if !hasmapto('<Plug>(RepeatRedo)', 'n') | nmap <C-R> <Plug>(RepeatRedo) | endif
+if !hasmapto('<Plug>(RepeatRedo)', 'n') | nmap <C-R> <Plug>(RepeatRedo)| endif
 
 augroup repeatPlugin
     autocmd!


### PR DESCRIPTION
Vim interprets `nmap <key> <mapping> ` as `nmap <key> <mapping><space>`. 
Here we do not want this and put `|` directly after `<mapping>`.