### PR TITLE
Revert order of feedkeys calls to fix counts

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -92,8 +92,8 @@ function! repeat#run(count)
         if ((v:version == 703 && has('patch100')) || (v:version == 704 && !has('patch601')))
             exe 'norm ' . r . cnt . s
         else
-            call feedkeys(r . cnt, 'ni')
             call feedkeys(s, 'i')
+            call feedkeys(r . cnt, 'ni')
         endif
     else
         if ((v:version == 703 && has('patch100')) || (v:version == 704 && !has('patch601')))


### PR DESCRIPTION
Since we are using the `i` flag, the feedkeys calls insert the keys instead of appending. That's why we need to insert the second part of the command before inserting the first part in front of it.

Close #45.