### PR TITLE
Fixed error produced with modified off

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -110,6 +110,9 @@ function! repeat#run(count)
 endfunction
 
 function! repeat#wrap(command,count)
+    if !&modifiable
+        return
+    endif
     let preserve = (g:repeat_tick == b:changedtick)
     exe 'norm! '.(a:count ? a:count : '').a:command . (&foldopen =~# 'undo\|all' ? 'zv' : '')
     if preserve


### PR DESCRIPTION
Before, when pressing <C-r> in a buffer that has &modified set to 0,
repeat would produce an error:

    Error detected while processing function repeat#wrap:
    line    2:
    E21: Cannot make changes, 'modifiable' is off
    Press ENTER or type command to continue

Now, repeat checks if the buffer is modifiable before executing.