### PR TITLE
Add abolish.vim to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@ it.
 
 The following plugins support repeat.vim:
 
+* [abolish.vim](https://github.com/tpope/vim-abolish)
 * [surround.vim](https://github.com/tpope/vim-surround)
 * [speeddating.vim](https://github.com/tpope/vim-speeddating)
 * [unimpaired.vim](https://github.com/tpope/vim-unimpaired)


### PR DESCRIPTION
The [abolish.vim](https://github.com/tpope/vim-abolish) README states that the coercion commands support repeat.vim so I have added it to the README here.