### PR TITLE
Make an explicit register on repeat override g:repeat_reg

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -73,17 +73,34 @@ function! repeat#setreg(sequence,register)
     let g:repeat_reg = [a:sequence, a:register]
 endfunction
 
+
+function! s:default_register()
+    let values = split(&clipboard, ',')
+    if index(values, 'unnamedplus') != -1
+        return '+'
+    elseif index(values, 'unnamed') != -1
+        return '*'
+    else
+        return '"'
+    endif
+endfunction
+
 function! repeat#run(count)
     try
         if g:repeat_tick == b:changedtick
             let r = ''
             if g:repeat_reg[0] ==# g:repeat_sequence && !empty(g:repeat_reg[1])
-                if g:repeat_reg[1] ==# '='
+                " Take the original register, unless another (non-default, we
+                " unfortunately cannot detect no vs. a given default register)
+                " register has been supplied to the repeat command (as an
+                " explicit override).
+                let regname = v:register ==# s:default_register() ? g:repeat_reg[1] : v:register
+                if regname ==# '='
                     " This causes a re-evaluation of the expression on repeat, which
                     " is what we want.
                     let r = '"=' . getreg('=', 1) . "\<CR>"
                 else
-                    let r = '"' . g:repeat_reg[1]
+                    let r = '"' . regname
                 endif
             endif
 


### PR DESCRIPTION
As with built-in commands, this allows to override the original register on repeat, e.g. `"a.` uses register `a` instead of the original one.

One limitation is that we cannot detect whether no or the default register has been given, so an override from a non-default to the default register (e.g. via `"".`) is not possible.
