### PR TITLE
feedkeys(..., 'i') sends keys in the wrong order in Vim 7.0/1/2

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -92,6 +92,9 @@ function! repeat#run(count)
             let cnt = c == -1 ? "" : (a:count ? a:count : (c ? c : ''))
             if ((v:version == 703 && has('patch100')) || (v:version == 704 && !has('patch601')))
                 exe 'norm ' . r . cnt . s
+            elseif v:version <= 703
+                call feedkeys(r . cnt, 'n')
+                call feedkeys(s, '')
             else
                 call feedkeys(s, 'i')
                 call feedkeys(r . cnt, 'ni')


### PR DESCRIPTION
The current implementation prefers `feedkeys(..., 'i')` and only falls back to `:normal` if Vim 7.4 does not have the 'i' flag and if Vim 7.3 supports `:normal` with count. For Vim 8.0 (and later), and also for versions between 7.0 and 7.3.99, `feedkeys(..., 'i')` is used. Due to the prepending action of the 'i' flag, keys must be submitted in reverse order; that's why `s` is submitted before `r . cnt`.  Vim 7.0...7.3.99 ignore the 'i' flag, though, and append the keys, which are now in the wrong order (this only matters if a register or count is given).

This fix adds a separate conditional branch for Vim versions before 7.3.100 that uses `feedkeys()` in the correct order and omits the ignored 'i' flag.
