### PR TITLE
Fix repeat after undo

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -134,7 +134,10 @@ function! repeat#wrap(command,count)
     call feedkeys((a:count ? a:count : '').a:command, 'n')
     exe (&foldopen =~# 'undo\|all' ? 'norm! zv' : '')
     if preserve
-        let g:repeat_tick = b:changedtick
+        augroup repeat_preserve_after_undo
+            autocmd!
+            autocmd TextChanged <buffer> let g:repeat_tick = b:changedtick | autocmd! repeat_preserve_after_undo
+        augroup END
     endif
 endfunction
 


### PR DESCRIPTION
This PR tries to fix the issue [#63](https://github.com/tpope/vim-repeat/issues/63).  It delays the ticks synchronization until the next `TextChanged`, which is necessary because `feedkeys()` does not execute the undo command immediately.  See [this comment](https://github.com/tpope/vim-repeat/issues/63#issuecomment-627085257) for more context.
