### PR TITLE
Rework error return to prevent off-by-one in Ex mode

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -86,6 +86,7 @@ function! s:default_register()
 endfunction
 
 function! repeat#run(count)
+    let s:errmsg = ''
     try
         if g:repeat_tick == b:changedtick
             let r = ''
@@ -124,9 +125,13 @@ function! repeat#run(count)
             endif
         endif
     catch /^Vim(normal):/
-        return 'echoerr v:errmsg'
+        let s:errmsg = v:errmsg
+        return 0
     endtry
-    return ''
+    return 1
+endfunction
+function! repeat#errmsg()
+    return s:errmsg
 endfunction
 
 function! repeat#wrap(command,count)
@@ -138,7 +143,7 @@ function! repeat#wrap(command,count)
     endif
 endfunction
 
-nnoremap <silent> <Plug>(RepeatDot)      :<C-U>exe repeat#run(v:count)<CR>
+nnoremap <silent> <Plug>(RepeatDot)      :<C-U>if !repeat#run(v:count)<Bar>echoerr repeat#errmsg()<Bar>endif<CR>
 nnoremap <silent> <Plug>(RepeatUndo)     :<C-U>call repeat#wrap('u',v:count)<CR>
 nnoremap <silent> <Plug>(RepeatUndoLine) :<C-U>call repeat#wrap('U',v:count)<CR>
 nnoremap <silent> <Plug>(RepeatRedo)     :<C-U>call repeat#wrap("\<Lt>C-R>",v:count)<CR>


### PR DESCRIPTION
My automated tests run Vim in silent batch mode (:help -s-ex), these also cover repeat of mappings via repeat.vim. Unfortunately, the combination of feedkeys() and :execute used in the repeat.vim implementation to return a potential caught error cause the line where the repeat mapping is executed to be increased, so for me the tests fail in a really strange way. The same problem can occur if someone uses repeats in silent batch mode (e.g. through a recorded macro) - though the source of the problem would be even harder to track down there - in my test run it at least was easily reproducible.

I raised this as a potential Vim bug in https://github.com/vim/vim/issues/7153, but Bram explained that it's a side effect of Ex mode (where empty lines make the cursor go to the next line, and as repeat#run() returns the empty String on the happy path, that's an empty line being executed). Recommendation from Bram is to pass the "x" flag for immediate execution to feedkeys() (which avoids the problem). However, in the context of repeat.vim this would mean that any errors resulting from the repeat mapping invocation would have to be caught inside repeat#run(), because they would then execute within the function's context, and not after it. Also, the "x" flag would not be supported by old Vim 7.3 and earlier.

Instead, I chose to avoid the problem by replacing the :execute with a more straightforward :call (actually an :if that tests a returned Boolean success flag), so instead of the clever direct execution of the returned :echoerr command, the error message instead is retrieved from a script-local variable via a new repeat#errmsg() getter. I use this idiom in all of my plugins through a set of utility functions (https://github.com/inkarkat/vim-ingo-library/blob/5bb32fd27aa37a767d92ed29eb76dd48a7b0c7d2/autoload/ingo/err.vim#L38-L41), too.
So by adding a little (well encapsulated) variable and getter, this problem can be avoided without touching the sensitive feedkeys() and try...catch logic within the plugin.