### PR TITLE
Avoid existing keymap override

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -148,16 +148,16 @@ nnoremap <silent> <Plug>(RepeatUndo)     :<C-U>call repeat#wrap('u',v:count)<CR>
 nnoremap <silent> <Plug>(RepeatUndoLine) :<C-U>call repeat#wrap('U',v:count)<CR>
 nnoremap <silent> <Plug>(RepeatRedo)     :<C-U>call repeat#wrap("\<Lt>C-R>",v:count)<CR>
 
-if !hasmapto('<Plug>(RepeatDot)', 'n')
+if maparg('.','n') ==# '' && !hasmapto('<Plug>(RepeatDot)', 'n')
     nmap . <Plug>(RepeatDot)
 endif
-if !hasmapto('<Plug>(RepeatUndo)', 'n')
+if maparg('u','n') ==# '' && !hasmapto('<Plug>(RepeatUndo)', 'n')
     nmap u <Plug>(RepeatUndo)
 endif
 if maparg('U','n') ==# '' && !hasmapto('<Plug>(RepeatUndoLine)', 'n')
     nmap U <Plug>(RepeatUndoLine)
 endif
-if !hasmapto('<Plug>(RepeatRedo)', 'n')
+if maparg('<C-R>','n') ==# '' && !hasmapto('<Plug>(RepeatRedo)', 'n')
     nmap <C-R> <Plug>(RepeatRedo)
 endif
 


### PR DESCRIPTION
It looks overriding some keymaps.

It already checks existing keymap for `U`, though,
also other keymaps `.`, `u`, `<C-R>` should do so, shouldn't them?

Related with the issue https://github.com/tpope/vim-repeat/issues/91, too.

#### How to Repro

```vim
" Check existing keymaps.
" Here some keymaps exist for `machakann/vim-highlightedundo` plugin.
:nmap . | nmap u | nmap U | nmap <C-R>
" No mapping found
" n  u             <Plug>(highlightedundo-undo)
" n  U             <Plug>(highlightedundo-Undo)
" n  <C-R>         <Plug>(highlightedundo-redo)

" Insert some text
i
foobar

" Still key mapping is not overrode yet.
:nmap . | nmap u | nmap U | nmap <C-R>
" No mapping found
" n  u             <Plug>(highlightedundo-undo)
" n  U             <Plug>(highlightedundo-Undo)
" n  <C-R>         <Plug>(highlightedundo-redo)

"---------------------------------------------------------------

" Use `tpope/vim-surround` plugin.
yss'

" Then, some of keymaps are overrode
:nmap . | nmap u | nmap U | nmap <C-R>
" n  .             <Plug>(RepeatDot)
" n  u             <Plug>(RepeatUndo)
" n  U             <Plug>(highlightedundo-Undo)
" n  <C-R>         <Plug>(RepeatRedo)
```

##### `.vimrc`

```vim
" vim: ft=vim et ts=4 sts=4 sw=4

" Vundle

set nocompatible               " be iMproved
filetype off                   " required!
set rtp+=~/.vim/bundle/Vundle.vim

call vundle#begin()

"-------------------------------------------------------------------------------

" let Vundle manage Vundle, required
Plugin 'VundleVim/Vundle.vim'

"...............................................................................

Plugin 'tpope/vim-repeat'
Plugin 'tpope/vim-surround'

Plugin 'machakann/vim-highlightedundo'

nmap u     <Plug>(highlightedundo-undo)
nmap <C-r> <Plug>(highlightedundo-redo)
nmap U     <Plug>(highlightedundo-Undo)
nmap g-    <Plug>(highlightedundo-gminus)
nmap g+    <Plug>(highlightedundo-gplus)

"-------------------------------------------------------------------------------

call vundle#end()           " required
filetype plugin indent on   " required!
```
