### PR TITLE
Flush typeahead buffer in repeat#wrap() so b:changedtick is up-to-date.

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -136,7 +136,7 @@ endfunction
 
 function! repeat#wrap(command,count)
     let preserve = (g:repeat_tick == b:changedtick)
-    call feedkeys((a:count ? a:count : '').a:command, 'n')
+    call feedkeys((a:count ? a:count : '').a:command, 'nx')
     exe (&foldopen =~# 'undo\|all' ? 'norm! zv' : '')
     if preserve
         let g:repeat_tick = b:changedtick

--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -136,10 +136,13 @@ endfunction
 
 function! repeat#wrap(command,count)
     let preserve = (g:repeat_tick == b:changedtick)
-    call feedkeys((a:count ? a:count : '').a:command, 'nx')
+    call feedkeys((a:count ? a:count : '').a:command, 'n')
     exe (&foldopen =~# 'undo\|all' ? 'norm! zv' : '')
     if preserve
-        let g:repeat_tick = b:changedtick
+        augroup repeat_preserve_after_undo
+            autocmd!
+            autocmd TextChanged <buffer> let g:repeat_tick = b:changedtick | autocmd! repeat_preserve_after_undo
+        augroup END
     endif
 endfunction
 


### PR DESCRIPTION
Fixes #94, fixes #63. See [this comment](https://github.com/tpope/vim-repeat/issues/94#issuecomment-1538344088) for an exaplanation of the issue.

#79 was a previous PR with the same fix that was abandoned after three years of inactivity.