### PR TITLE
Publish tagged releases to LuaRocks.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: "release"
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          detailed_description: |
+            enable repeating supported plugin maps with "."
+          license: "VIM"


### PR DESCRIPTION
### Summary

This PR is part of a push to get (neo)vim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.
* I'm aware this is a vimscript plugin. But that does not prevent `luarocks` from being able to package this :smile: 
  In fact, as a popular plugin that many other plugins depend on, having `vim-repeat` on LuaRocks.org
  could be great for further adoption.
* If you support this, please let me know if you would like me to add equivalent PRs to your other plugins.


### Things done:

* Add a workflow that publishes tags to LuaRocks when a tag is pushed.

### Notes

* Tagged releases are installed locally and then published to LuaRocks.org.
  On PRs, a test release is installed, but not published.
* For the release workflow to work, someone with a LuaRocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.

I have tested this with the [`quick-scope`](https://github.com/unblevable/quick-scope) plugin in Neovim using the following minimal config:

```console
mkdir /tmp/nvim-test
luarocks install --tree /tmp/nvim-test quick-scope
cd /tmp/nvim-test
nvim minimal.lua # paste minimal.lua below
nvim -u minimal.lua test.txt
```

```lua
-- minimal.lua

-- Ignore default config
local config_path = vim.fn.stdpath('config')
vim.opt.rtp:remove(config_path)

-- Ignore default plugins
local data_path = vim.fn.stdpath('data')
local pack_path = data_path .. '/site'
vim.opt.packpath:remove(pack_path)

vim.opt.runtimepath:append('lib/luarocks/rocks-5.1/quick-scope/scm-1/')
```

...and it works :tada: 

![image](https://github.com/unblevable/quick-scope/assets/12857160/ea7bd712-6227-486f-ba21-d9ba44de910c)

__Adding the API key (screen shot)__
![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211071297-afb129be-7a8f-4662-b282-9d52bb0286de.png)
