### PR TITLE
Move required machinery into `plugin/repeat.vim`.

### DIFF
--- a/autoload/repeat.vim
+++ b/autoload/repeat.vim
@@ -1,56 +1,4 @@
 " repeat.vim - Let the repeat command repeat plugin maps
-" Maintainer:   Tim Pope
-" Version:      1.2
-" GetLatestVimScripts: 2136 1 :AutoInstall: repeat.vim
-
-" Installation:
-" Place in either ~/.vim/plugin/repeat.vim (to load at start up) or
-" ~/.vim/autoload/repeat.vim (to load automatically as needed).
-"
-" License:
-" Copyright (c) Tim Pope.  Distributed under the same terms as Vim itself.
-" See :help license
-"
-" Developers:
-" Basic usage is as follows:
-"
-"   silent! call repeat#set("\<Plug>MappingToRepeatCommand",3)
-"
-" The first argument is the mapping that will be invoked when the |.| key is
-" pressed.  Typically, it will be the same as the mapping the user invoked.
-" This sequence will be stuffed into the input queue literally.  Thus you must
-" encode special keys by prefixing them with a backslash inside double quotes.
-"
-" The second argument is the default count.  This is the number that will be
-" prefixed to the mapping if no explicit numeric argument was given.  The
-" value of the v:count variable is usually correct and it will be used if the
-" second parameter is omitted.  If your mapping doesn't accept a numeric
-" argument and you never want to receive one, pass a value of -1.
-"
-" Make sure to call the repeat#set function _after_ making changes to the
-" file.
-"
-" For mappings that use a register and want the same register used on
-" repetition, use:
-"
-"   silent! call repeat#setreg("\<Plug>MappingToRepeatCommand", v:register)
-"
-" This function can (and probably needs to be) called before making changes to
-" the file (as those typically clear v:register).  Therefore, the call sequence
-" in your mapping will look like this:
-"
-"   nnoremap <silent> <Plug>MyMap
-"   \   :<C-U>execute 'silent! call repeat#setreg("\<lt>Plug>MyMap", v:register)'<Bar>
-"   \   call <SID>MyFunction(v:register, ...)<Bar>
-"   \   silent! call repeat#set("\<lt>Plug>MyMap")<CR>
-
-if exists("g:loaded_repeat") || &cp || v:version < 800
-    finish
-endif
-let g:loaded_repeat = 1
-
-let g:repeat_tick = -1
-let g:repeat_reg = ['', '']
 
 " Special function to avoid spurious repeats in a related, naturally repeating
 " mapping when your repeatable mapping doesn't increase b:changedtick.
@@ -72,7 +20,6 @@ endfunction
 function! repeat#setreg(sequence,register)
     let g:repeat_reg = [a:sequence, a:register]
 endfunction
-
 
 function! s:default_register()
     let values = split(&clipboard, ',')
@@ -119,6 +66,7 @@ function! repeat#run(count)
     endtry
     return 1
 endfunction
+
 function! repeat#errmsg()
     return s:errmsg
 endfunction
@@ -128,29 +76,5 @@ function! repeat#wrap(command,count)
     let preserve = g:repeat_tick == b:changedtick ? ":let g:repeat_tick = b:changedtick\r" : ''
     return (a:count ? a:count : '') . a:command . preserve . foldopen
 endfunction
-
-nnoremap <silent> <Plug>(RepeatDot)      :<C-U>if !repeat#run(v:count)<Bar>echoerr repeat#errmsg()<Bar>endif<CR>
-nmap <silent><expr><script> <Plug>(RepeatUndo)     repeat#wrap('u',v:count)
-nmap <silent><expr><script> <Plug>(RepeatUndoLine) repeat#wrap('U',v:count)
-nmap <silent><expr><script> <Plug>(RepeatRedo)     repeat#wrap("\022",v:count)
-
-if !hasmapto('<Plug>(RepeatDot)', 'n')
-    nmap . <Plug>(RepeatDot)
-endif
-if !hasmapto('<Plug>(RepeatUndo)', 'n')
-    nmap u <Plug>(RepeatUndo)
-endif
-if maparg('U','n') ==# '' && !hasmapto('<Plug>(RepeatUndoLine)', 'n')
-    nmap U <Plug>(RepeatUndoLine)
-endif
-if !hasmapto('<Plug>(RepeatRedo)', 'n')
-    nmap <C-R> <Plug>(RepeatRedo)
-endif
-
-augroup repeatPlugin
-    autocmd!
-    autocmd BufLeave,BufWritePre,BufReadPre * let g:repeat_tick = (g:repeat_tick == b:changedtick || g:repeat_tick == 0) ? 0 : -1
-    autocmd BufEnter,BufWritePost * if g:repeat_tick == 0|let g:repeat_tick = b:changedtick|endif
-augroup END
 
 " vim:set ft=vim et sw=4 sts=4:

--- a/plugin/repeat.vim
+++ b/plugin/repeat.vim
@@ -1,0 +1,81 @@
+" repeat.vim - Let the repeat command repeat plugin maps
+" Maintainer:   Tim Pope
+" Version:      1.2
+" GetLatestVimScripts: 2136 1 :AutoInstall: repeat.vim
+
+" Installation:
+" Use a plugin manager.
+"
+" For manual installation copy plugin/repeat.vim and autoload/repeat.vim into
+" ~/.vim/plugin/repeat.vim and ~/.vim/autoload/repeat.vim respectively.
+"
+" License:
+" Copyright (c) Tim Pope.  Distributed under the same terms as Vim itself.
+" See :help license
+"
+" Developers:
+" Basic usage is as follows:
+"
+"   silent! call repeat#set("\<Plug>MappingToRepeatCommand",3)
+"
+" The first argument is the mapping that will be invoked when the |.| key is
+" pressed.  Typically, it will be the same as the mapping the user invoked.
+" This sequence will be stuffed into the input queue literally.  Thus you must
+" encode special keys by prefixing them with a backslash inside double quotes.
+"
+" The second argument is the default count.  This is the number that will be
+" prefixed to the mapping if no explicit numeric argument was given.  The
+" value of the v:count variable is usually correct and it will be used if the
+" second parameter is omitted.  If your mapping doesn't accept a numeric
+" argument and you never want to receive one, pass a value of -1.
+"
+" Make sure to call the repeat#set function _after_ making changes to the
+" file.
+"
+" For mappings that use a register and want the same register used on
+" repetition, use:
+"
+"   silent! call repeat#setreg("\<Plug>MappingToRepeatCommand", v:register)
+"
+" This function can (and probably needs to be) called before making changes to
+" the file (as those typically clear v:register).  Therefore, the call sequence
+" in your mapping will look like this:
+"
+"   nnoremap <silent> <Plug>MyMap
+"   \   :<C-U>execute 'silent! call repeat#setreg("\<lt>Plug>MyMap", v:register)'<Bar>
+"   \   call <SID>MyFunction(v:register, ...)<Bar>
+"   \   silent! call repeat#set("\<lt>Plug>MyMap")<CR>
+
+if exists("g:loaded_repeat") || &cp || v:version < 800
+    finish
+endif
+let g:loaded_repeat = 1
+
+let g:repeat_tick = -1
+let g:repeat_reg = ['', '']
+
+nnoremap <silent> <Plug>(RepeatDot)      :<C-U>if !repeat#run(v:count)<Bar>echoerr repeat#errmsg()<Bar>endif<CR>
+nmap <silent><expr><script> <Plug>(RepeatUndo)     repeat#wrap('u',v:count)
+nmap <silent><expr><script> <Plug>(RepeatUndoLine) repeat#wrap('U',v:count)
+nmap <silent><expr><script> <Plug>(RepeatRedo)     repeat#wrap("\022",v:count)
+
+if !hasmapto('<Plug>(RepeatDot)', 'n')
+    nmap . <Plug>(RepeatDot)
+endif
+if !hasmapto('<Plug>(RepeatUndo)', 'n')
+    nmap u <Plug>(RepeatUndo)
+endif
+if maparg('U','n') ==# '' && !hasmapto('<Plug>(RepeatUndoLine)', 'n')
+    nmap U <Plug>(RepeatUndoLine)
+endif
+if !hasmapto('<Plug>(RepeatRedo)', 'n')
+    nmap <C-R> <Plug>(RepeatRedo)
+endif
+
+augroup repeatPlugin
+    autocmd!
+    autocmd BufLeave,BufWritePre,BufReadPre * let g:repeat_tick = (g:repeat_tick == b:changedtick || g:repeat_tick == 0) ? 0 : -1
+    autocmd BufEnter,BufWritePost * if g:repeat_tick == 0|let g:repeat_tick = b:changedtick|endif
+augroup END
+
+" vim:set ft=vim et sw=4 sts=4:


### PR DESCRIPTION
`repeat.vim` was written to be used as either an autoloaded script or a normally loaded script.

In particular, as mappings used to be defined by the autoload script, they would only be actually injected if any other plugin has used the repeat functionality.

In practice, this creates problems as the mapping is not stable.  One cannot define a custom mapping to `<Plug>(RepeatUndo)`, as the existence of the mapping from `<Plug>(RepeatUndo)` is subject to the prior execution of any code that uses the repeat functionality.

Similarly, when loading a session that was stored when `u` was remapped to `<Plug>(RepeatUndo)` is almost guaranteed to be an issue.  As `u` is already remapped, but the plugin has not constructed the next step, mapping `<Plug>(RepeatUndo)` to the correct function.

Just setting up the mappings seems like a solid solution to these problems.  While it is a bit less efficient, if the user has enabled this plugin, they probably rely on it, and so the optimizations are most likely negligible.

Also updated the installation instructions.  I would imagine most people use plugin managers today.  And so it is no longer useful, in my mind, to be able to decide if the plugin will be eagerly or lazily loaded.  It just complicates the installation process.

---

This should address https://github.com/tpope/vim-repeat/pull/84 without a hack.
Someone can just create a mapping and exact it to always work.

My main concern is the breakage during session restore.